### PR TITLE
Allow passing preloaded canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ $ npm install --save pinch-zoom-canvas
 ## Options
 
 - `canvas` mandatory. It is a DOM element where the image is rendered.
-- `path` mandatory. It is a path url of image.
+- `path` one of path or canvasimg is mandatory. It is a path url of image.
+- `canvasimg` one of path or canvasimg is mandatory. Canvas object with preloaded image.
 - `doubletap` optional (default `true`). Double tap for zooming.
 - `momentum` optional (defalut `false`). Set a momentum when the image is dragged. This parameter require [Impetus](https://github.com/SonoIo/impetus) library.
 - `maxZoom` optional (default `2`). It is the zoom max.
@@ -98,6 +99,40 @@ var pinchZoom = new PinchZoomCanvas({
 		console.log("---> zoom is %s", zoom);
 	}
 	});
+```
+
+## Usage with canvasimg
+
+```html
+<script src="https://raw.githubusercontent.com/blueimp/JavaScript-Load-Image/master/js/load-image.all.min.js"></script>
+<canvas id="mycanvas" style="width: 100%; height: 100%"></canvas>
+```
+
+```js
+var pinchZoom;
+loadImage(
+		'your image url',
+		function(canvasimg) {
+			var pinchZoom = new PinchZoomCanvas({
+				canvas: document.getElementById('mycanvas'),
+				canvasimg: canvasimg,
+				momentum: true,
+				zoomMax: 2,
+				doubletap: true,
+				onZoomEnd: function (zoom, zoomed) {
+					console.log("---> is zoomed: %s", zoomed);
+					console.log("---> zoom end at %s", zoom);
+				},
+				onZoom: function (zoom) {
+					console.log("---> zoom is %s", zoom);
+				}
+				});
+		},
+		{
+			orientation: true,
+			canvas: true
+		}
+);
 ```
 
 ## Licence

--- a/pinch-zoom-canvas.js
+++ b/pinch-zoom-canvas.js
@@ -13,8 +13,8 @@
 	var timeout;
 	var cache = [];
 	var PinchZoomCanvas = function(options) {
-		if( !options || !options.canvas || !options.path) {
-			throw 'PinchZoomCanvas constructor: missing arguments canvas or path';
+		if( !options || !options.canvas || !(options.path || options.canvasimg)) {
+			throw 'PinchZoomCanvas constructor: missing arguments canvas or one of path or canvasimg';
 		}
 
 		// Check if exists function requestAnimationFrame
@@ -83,16 +83,22 @@
 		this.onTouchEnd   = this.onTouchEnd.bind(this);
 		this.render       = this.render.bind(this);
 
-		// Load the image
-		this.imgTexture = new Image();
-		this.imgTexture.onload = function(){
-			if ( this.destroyed )
-				return;
+		if (options.path) {
+			// Load the image
+			this.imgTexture = new Image();
+			this.imgTexture.onload = function(){
+				if ( this.destroyed )
+					return;
+				requestAnimationFrame(this.render);
+				this._setEventListeners();
+			}.bind(this);
+			this.imgTexture.src = options.path;
+		} else {
+			// Image is preloaded in canvasimg
+			this.imgTexture = options.canvasimg;
 			requestAnimationFrame(this.render);
 			this._setEventListeners();
-		}.bind(this);
-		this.imgTexture.src = options.path;
-
+		}
 	};
 
 	PinchZoomCanvas.prototype = {

--- a/pinch-zoom-canvas.js
+++ b/pinch-zoom-canvas.js
@@ -308,6 +308,14 @@
 			this.canvas = null;
 		},
 
+		clearCache: function() {
+			if (timeout) {
+				clearTimeout(timeout);
+				timeout = undefined;
+			}
+			cache = [];
+		},
+
 		//
 		// Private
 		//


### PR DESCRIPTION
Adding an extra option canvasimg that lets the user of the library pass a canvas with the image preloaded, this allows for instance to get a rotated picture from a cellphone and display it correctly based on the EXIF header.

A little context, this [cordova plugin](https://github.com/cordova-plugin-camera-preview/cordova-plugin-camera-preview) uses base64 encoded images instead of files, on a Samsung A5 2017 (8 cores, 3GB RAM) rotating a 16MP images takes something like 5 seconds because and all of this time is been spent on generating the base64 string after rotation. I have a change I'm gonna submit to them which is instead of stripping off the rotation exif header and rotate on Java, just add the header and let the browser rotate, as it can use the GPU

With the change to your package I can get a rotated image which I can zoom-in in near realtime.