### PR TITLE
Allow clearing cache, to avoid leaking of memory

### DIFF
--- a/pinch-zoom-canvas.js
+++ b/pinch-zoom-canvas.js
@@ -302,6 +302,14 @@
 			this.canvas = null;
 		},
 
+		clearCache: function() {
+			if (timeout) {
+				clearTimeout(timeout);
+				timeout = undefined;
+			}
+			cache = [];
+		},
+
 		//
 		// Private
 		//


### PR DESCRIPTION
The caching feature is super nice, but it's actually risky. If you
start creating big enough objects at a high frequency (less than 1
minute) then the cache starts growing and growing which leads to
a memory leak. This is more notoriuous on mobile devices, and
specially when the module is used to display 16MP images.

Here you can see the memory consumption of my ionic app after 7 creations and destruction's of pinch-zoom-canvas objects:
![object-leak](https://user-images.githubusercontent.com/545883/37248006-7504e8b4-24c6-11e8-8c02-5fe0e0a80b05.png)

And here you can see the same after I applied this patch:
![no-more-leak](https://user-images.githubusercontent.com/545883/37248011-7e4c51c8-24c6-11e8-9491-3b032ea7af2d.png)

